### PR TITLE
Added option to include cue indexes when saving file

### DIFF
--- a/pyvtt/vttfile.py
+++ b/pyvtt/vttfile.py
@@ -244,22 +244,23 @@ class WebVTTFile(UserList, object):
                         error.args += (''.join(source), )
                         cls._handle_error(error, error_handling, index)
 
-    def save(self, path=None, encoding=None, eol=None):
+    def save(self, path=None, encoding=None, eol=None, include_indexes=False):
         """
         save([path][, encoding][, eol])
 
         Use initial path if no other provided.
         Use initial encoding if no other provided.
         Use initial eol if no other provided.
+        Set include_indexes to True to include the cue indexes.
         """
         path = path or self.path
         encoding = encoding or self.encoding
 
         save_file = codecs.open(path, 'w+', encoding=encoding)
-        self.write_into(save_file, eol=eol)
+        self.write_into(save_file, eol=eol, include_indexes=include_indexes)
         save_file.close()
 
-    def write_into(self, output_file, eol=None, encoding=None):
+    def write_into(self, output_file, eol=None, encoding=None, include_indexes=False):
         """
         write_into(output_file [, eol])
 
@@ -267,6 +268,8 @@ class WebVTTFile(UserList, object):
 
         `output_file` -> Any instance that respond to `write()`, typically a
         file object
+
+        If include_indexes is True the cue indexes will be included in the file.
         """
         self._check_valid_len()
         output_eol = eol or self.eol
@@ -276,6 +279,8 @@ class WebVTTFile(UserList, object):
             string_repr = str(item)
             if output_eol != '\n':
                 string_repr = string_repr.replace('\n', output_eol)
+            if include_indexes:
+                output_file.write(str(item.index) + output_eol)
             output_file.write(string_repr)
             # Only add trailing eol if it's not already present.
             # It was kept in the WebVTTItem's text before but it really

--- a/tests/test_vttfile.py
+++ b/tests/test_vttfile.py
@@ -196,6 +196,16 @@ class TestSerialization(unittest.TestCase):
                           bytes(open(overwrite_target_path, 'rb').read()))
 
         os.remove(overwrite_target_path)
+        
+    def test_save_with_indexes(self):
+        file = pyvtt.open(os.path.join(self.static_path, 'no-indexes.srt'))
+        file.clean_indexes()
+        file_with_indexes = os.path.join(file_path, 'tests', 'vtt_test', 'file_with_indexes.vtt')
+        file_with_indexes_target_path = os.path.join(file_path, 'tests', 'vtt_test', 'file_with_indexes_target.vtt')
+        file.save(file_with_indexes_target_path, include_indexes=True)
+        self.assertEqual(bytes(open(file_with_indexes, 'rb').read()),
+                          bytes(open(file_with_indexes_target_path, 'rb').read()))
+        os.remove(file_with_indexes_target_path)
 
     def test_eol_convertion(self):
 

--- a/tests/vtt_test/file_with_indexes.vtt
+++ b/tests/vtt_test/file_with_indexes.vtt
@@ -1,0 +1,37 @@
+WEBVTT
+
+1
+00:00:06.500 --> 00:00:09.000
+About 2 months ago I found myself on
+the comment section of YouTube
+
+2
+00:00:11.000 --> 00:00:17.000
+And I was commenting,
+unfortunately I was commenting,
+on a video about the famous Ayn Rand
+
+3
+00:00:19.000 --> 00:00:24.000
+And I
+posted underneath against
+this woman's tirades,
+against what is essentially
+the human race.
+
+4
+00:00:25.000 --> 00:00:31.000
+that, this monetary system seems to have no point, seems to actually hinder people
+
+5
+00:00:31.000 --> 00:00:36.000
+and hinder progress, and one of the responses I got, I didn't answer it, was:
+
+6
+00:00:37.000 --> 00:00:43.000
+what actually money creates is an incentive to invent the new items, that's the driving force behind it
+
+7
+00:00:43.000 --> 00:00:50.000
+So what I thought I do is instead if answering on a YouTube comment is organize a global awareness day
+


### PR DESCRIPTION
The WebVTT files I work with include the cue indexes so I added the option to save the file with the indexes.